### PR TITLE
Refactor constructor mode preview and fix bugs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,10 +59,11 @@ h1 {
 }
 
 #preview-container {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 10px;
-    min-height: 60px;
+    display: none; /* Oculto por defecto */
+    position: absolute;
+    z-index: 100;
+    pointer-events: none; /* Para que no interfiera con el cursor */
+    min-height: auto;
 }
 
 #next-piece-preview {


### PR DESCRIPTION
This commit introduces several improvements to the "Constructor" game mode:

1.  The piece preview now follows the mouse cursor, allowing the player to see where the piece will be placed. The old static preview container at the top has been removed.
2.  The cards in the preview are now correctly sized at 80x120 pixels, matching the game board cells.
3.  A bug has been fixed where the preview was showing the *next* piece instead of the *current* piece that the player is about to place. The preview now accurately reflects the current piece and its rotation.