### PR TITLE
feat: Add leaderboards for each game mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,46 @@
         <div class="modal-content">
             <h2 id="end-game-title">Juego Terminado</h2>
             <p>Tu puntuación final: <span id="final-score">0</span></p>
+
+            <!-- Formulario para récord -->
+            <div id="highscore-form" style="display: none;">
+                <p>¡Nuevo récord! Ingresá tu nombre:</p>
+                <input type="text" id="player-name" placeholder="Tu nombre" maxlength="15">
+                <button id="save-score-button">Guardar</button>
+            </div>
+
             <div class="mode-buttons">
                 <button id="play-constructor">Constructor</button>
                 <button id="play-espejo">Espejo</button>
                 <button id="play-cascada">Cascada</button>
+                <button id="view-leaderboard-button" style="display: none;">Ver Leaderboard</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal de Leaderboard -->
+    <div id="leaderboard-modal" style="display: none;">
+        <div class="modal-content">
+            <h2>Leaderboard</h2>
+            <div id="leaderboard-container">
+                <div class="leaderboard-column">
+                    <h3>🏗️ Constructor</h3>
+                    <ol id="leaderboard-constructor"></ol>
+                </div>
+                <div class="leaderboard-column">
+                    <h3>⚖️ Espejo</h3>
+                    <ol id="leaderboard-espejo"></ol>
+                </div>
+                <div class="leaderboard-column">
+                    <h3>🌊 Cascada</h3>
+                    <ol id="leaderboard-cascada"></ol>
+                </div>
+            </div>
+            <div class="mode-buttons">
+                <button id="play-constructor-from-leaderboard">Constructor</button>
+                <button id="play-espejo-from-leaderboard">Espejo</button>
+                <button id="play-cascada-from-leaderboard">Cascada</button>
+                <button id="close-leaderboard-button">Cerrar</button>
             </div>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -169,7 +169,7 @@ button:disabled {
 }
 
 /* Modal Styles */
-#welcome-modal, #end-game-modal {
+#welcome-modal, #end-game-modal, #leaderboard-modal {
     position: fixed;
     top: 0;
     left: 0;
@@ -263,7 +263,79 @@ button:disabled {
     border-color: #005a9e;
 }
 
+#highscore-form {
+    margin: 20px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+#highscore-form input {
+    padding: 8px;
+    font-size: 1em;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    width: 80%;
+    max-width: 250px;
+    text-align: center;
+}
+
+#highscore-form button {
+    padding: 8px 16px;
+}
+
+#leaderboard-container {
+    display: flex;
+    justify-content: space-around;
+    gap: 20px;
+    margin: 20px 0;
+    text-align: left;
+}
+
+.leaderboard-column {
+    flex: 1;
+    min-width: 150px;
+}
+
+.leaderboard-column h3 {
+    margin: 0 0 10px 0;
+    font-size: 1em;
+    text-align: center;
+    padding-bottom: 5px;
+    border-bottom: 2px solid var(--accent-color);
+}
+
+.leaderboard-column ol {
+    padding-left: 20px;
+    margin: 0;
+    font-size: 0.9em;
+    list-style-type: decimal;
+}
+
+.leaderboard-column li {
+    margin-bottom: 5px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.leaderboard-column li span:first-child {
+    font-weight: bold;
+    margin-right: 10px;
+}
+
 /* Responsive */
+@media (max-width: 600px) {
+    #leaderboard-container {
+        flex-direction: column;
+        align-items: center;
+    }
+    .leaderboard-column {
+        width: 100%;
+        max-width: 300px;
+    }
+}
+
 @media (max-width: 480px) {
     :root {
         --card-width: 35px;


### PR DESCRIPTION
Implements leaderboards for the 'Constructor', 'Espejo', and 'Cascada' game modes.

- Scores are saved to `localStorage` to persist between sessions.
- When a player achieves a top-10 score, the game over modal prompts them to enter their name.
- After saving, a "View Leaderboard" button appears.
- A new leaderboard modal displays the top 10 scores for each mode in a three-column layout.
- Players can start a new game directly from either the game over or leaderboard modals.