### PR TITLE
feat: Implement card falling in Builder mode and highlighting in Mirr…

### DIFF
--- a/script.js
+++ b/script.js
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 
                 // Agregar clases especiales según el modo
                 if (gameMode === 'espejo' && isHighlighted(r, c)) {
-                    slot.classList.add('highlight');
+                    slot.classList.add('shadow-highlight');
                 }
                 
                 const card = board[r][c];
@@ -221,6 +221,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Event listeners según el modo
                 if (gameMode === 'espejo') {
                     slot.addEventListener('click', () => handleEspejoClick(r, c));
+                    slot.addEventListener('mouseover', () => handleEspejoMouseOver(r, c));
+                    slot.addEventListener('mouseout', () => handleEspejoMouseOut());
                 }
                 
                 gameBoard.appendChild(slot);
@@ -489,6 +491,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         
+        // Aplicar gravedad para que la pieza caiga
+        applyGravity();
+
         // Avanzar a la siguiente pieza
         currentPiece = nextPiece;
         nextPiece = createPiece(Math.random() < 0.5 ? 'trio' : 'quad');
@@ -574,6 +579,34 @@ document.addEventListener('DOMContentLoaded', () => {
         endButton.style.display = 'inline-block';
         
         updateUI();
+        renderBoard();
+    }
+
+    function handleEspejoMouseOver(row, col) {
+        if (!gameRunning || gameMode !== 'espejo') return;
+
+        espejoHighlighted = [];
+        let mirrorCol;
+        if (col < 4) {
+            mirrorCol = col + 4;
+        } else {
+            mirrorCol = col - 4;
+        }
+
+        if (board[row][col]) {
+            espejoHighlighted.push({ row, col });
+        }
+        if (board[row][mirrorCol]) {
+            espejoHighlighted.push({ row, col: mirrorCol });
+        }
+
+        renderBoard();
+    }
+
+    function handleEspejoMouseOut() {
+        if (!gameRunning || gameMode !== 'espejo') return;
+
+        espejoHighlighted = [];
         renderBoard();
     }
 

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,12 @@ h1 {
     background-color: #e6f3ff;
 }
 
+.card-slot.shadow-highlight {
+    box-shadow: 0 0 8px 2px rgba(0, 122, 204, 0.5);
+    border-color: var(--accent-color);
+    z-index: 20;
+}
+
 .espejo-mode .card-slot:nth-child(8n+4) {
     border-right: 3px solid var(--primary-color);
 }


### PR DESCRIPTION
…or mode

This commit introduces two enhancements to the game modes as per the user's request.

In "Builder" mode:
- When a piece is placed, it now "falls" down into any empty spaces below it. This is achieved by calling the `applyGravity()` function after a piece is placed.

In "Mirror" mode:
- When hovering over a card, both the card and its corresponding mirror card are now highlighted with a shadow effect.
- This provides better visual feedback to the player about the effect of a potential move.
- Added `handleEspejoMouseOver` and `handleEspejoMouseOut` event handlers.
- Introduced a `shadow-highlight` CSS class for the effect.