### PR TITLE
Rework Cascada game mode with new mechanics

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -141,6 +141,23 @@ h1 {
     transition: all 0.3s ease;
 }
 
+.cascada-falling-card {
+    position: absolute;
+    width: var(--card-width);
+    height: var(--card-height);
+    z-index: 20;
+    pointer-events: none;
+    transition: top 2.0s ease-in, left 0.2s ease-out;
+    display: none; /* Hidden by default */
+}
+
+.cascada-falling-card .card-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    border-radius: 2px;
+}
+
 #controls {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
This commit implements three major changes to the "Cascada" game mode based on user feedback:

1. Visible Falling Card: The card to be dropped is now always visible. It appears as a preview above the board and animates its fall into the selected column. The game loop has been refactored from `setInterval` to a `setTimeout`-based chain to properly handle the animation sequence.

2. Rank-Based Matching: The matching logic has been changed from suits to ranks. Groups of two or more adjacent cards with the same number are now cleared from the board.

3. Mouse Controls: The control scheme has been changed from keyboard arrows to mouse clicks. The player can now click on any column to choose where the next card will be dropped. The old keyboard listener has been removed.

Additionally, the falling speed of the card has been reduced to a quarter of its previous speed by increasing the animation duration from 0.5s to 2.0s.