### PR TITLE
feat(game): Finalize adjustments for Cascade game mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -757,6 +757,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return false;
         }
 
+        fallingColumn = 4;
         fallingCard = cascadaDeck.shift();
 
         fallingCardContainer.innerHTML = '';
@@ -804,7 +805,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function cascadaGameStep() {
         if (!gameRunning || gamePaused) return;
         if (spawnNewCard()) {
-            cascadaTimeoutId = setTimeout(dropNextCard, 2500);
+            dropNextCard();
         }
     }
 
@@ -853,7 +854,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const gameContainerRect = document.getElementById('game-container').getBoundingClientRect();
         const gameBoardOffsetLeft = gameBoardRect.left - gameContainerRect.left;
         
-        const left = gameBoardOffsetLeft + fallingColumn * (cardWidth + gap);
+        const left = gameBoardOffsetLeft + fallingColumn * (cardWidth + gap) + 320;
         const top = gameBoard.offsetTop - firstSlotRect.height - 5;
 
         fallingCardContainer.style.left = `${left}px`;


### PR DESCRIPTION
This commit introduces and refines several adjustments to the 'Cascada' game mode based on iterative user feedback.

The following changes have been implemented:

1. The falling card now consistently appears in the center of the board at the start of its fall. This is achieved by resetting its column position for every new card.

2. The 2.5-second delay before the card begins to fall has been removed. The card now starts its descent immediately after appearing, allowing the user to guide it while it is in motion.

3. The horizontal position of the falling card has been fine-tuned with a pixel-based offset to ensure it is visually centered correctly on the board, as per user requests. The final offset is 320px.