### PR TITLE
feat: Habilitar la rotación de grupos de cuatro naipes

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,8 +112,13 @@ document.addEventListener('DOMContentLoaded', () => {
             } else { // Horizontal -> Vertical
                 piece.shape = [[0], [1], [2]];
             }
+        } else if (piece.type === 'quad') {
+            // Rotar las cartas en sentido horario:
+            // 0 1   ->   2 0
+            // 2 3   ->   3 1
+            const cards = piece.cards;
+            piece.cards = [cards[2], cards[0], cards[3], cards[1]];
         }
-        // Los cuadrados no necesitan rotación
     }
 
     function clearBoard() {


### PR DESCRIPTION
En el modo de juego "Constructor", ahora se pueden rotar los grupos de cuatro naipes en sentido horario.

La rotación sigue la siguiente lógica:
- El naipe de arriba a la izquierda se mueve a la posición de arriba a la derecha.
- El naipe de arriba a la derecha se mueve a la posición de abajo a la derecha.
- El naipe de abajo a la derecha se mueve a la posición de abajo a la izquierda.
- El naipe de abajo a la izquierda se mueve a la posición de arriba a la izquierda.

Esto se logra reordenando el array de naipes de la pieza 'quad' en la función `rotatePiece`.