### PR TITLE
feat: Allow right-click to rotate pieces in Builder mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -402,6 +402,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameBoard.addEventListener('mousemove', handleBoardMouseMove);
         gameBoard.addEventListener('mouseleave', handleBoardMouseLeave);
         gameBoard.addEventListener('click', handleConstructorClick);
+        gameBoard.addEventListener('contextmenu', handleRightClick);
     }
 
     function renderPiecePreview() {
@@ -543,6 +544,11 @@ document.addEventListener('DOMContentLoaded', () => {
             renderPiecePreview();
             renderBoard();
         }
+    }
+
+    function handleRightClick(e) {
+        e.preventDefault();
+        handleRotate();
     }
 
     function handleBoardMouseMove(e) {
@@ -894,6 +900,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (gameMode === 'constructor') {
             gameBoard.removeEventListener('mousemove', handleBoardMouseMove);
             gameBoard.removeEventListener('mouseleave', handleBoardMouseLeave);
+            gameBoard.removeEventListener('click', handleConstructorClick);
+            gameBoard.removeEventListener('contextmenu', handleRightClick);
             previewContainer.style.display = 'none';
         }
 


### PR DESCRIPTION
This commit adds the functionality to rotate the current piece in the "Constructor" (Builder) game mode by right-clicking on the game board.

A `contextmenu` event listener is added to the game board, which prevents the default menu and triggers the existing rotation logic. The event listener is properly removed when the game ends or the mode is changed.

This provides an alternative and more intuitive way for players to rotate pieces, in addition to the existing 'Rotate' button.